### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ project(SurfaceWrapSolidify)
 set(EXTENSION_HOMEPAGE "https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify")
 set(EXTENSION_CATEGORY "Segmentation")
 set(EXTENSION_CONTRIBUTORS "Sebastian Andress (LMU Munich)")
-set(EXTENSION_DESCRIPTION "This extension adds a 'Wrap Solidify' effect to the segment editor.")
+set(EXTENSION_DESCRIPTION "A Segment Editor Extension that filters the surface of a segment using a combination of shrinkwrapping and raycasting.")
 set(EXTENSION_ICONURL "https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify/raw/master/SurfaceWrapSolidify.png")
-set(EXTENSION_SCREENSHOTURLS "https://github.com/sebastianandress/Slicer-SurfaceWrapSolidify/raw/master/Resources/Screenshots/screenshot1.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/sebastianandress/Slicer-SurfaceWrapSolidify/master/Resources/Screenshots/screenshot4.png")
 set(EXTENSION_DEPENDS "NA")
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.